### PR TITLE
Refactor get_extended_namespace() and setup unit tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	colors="true"
+>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/src/Abstracts/AbstractCommand.php
+++ b/src/Abstracts/AbstractCommand.php
@@ -127,4 +127,34 @@ abstract class AbstractCommand implements ExtensibleInterface, CallableInterface
 			}
 		}
 	}
+
+	/**
+	 * Get the namespace of the extended classes to be loaded.
+	 *
+	 * This is use to get the fully qualified class name of the sub commands
+	 * and args that will autoload.
+	 *
+	 * Command autoloads SubCommands.
+	 * SubCommands autoloads Args.
+	 *
+	 * @since 0.0.1
+	 * @return string
+	 * @throws \Exception
+	 */
+	public function get_extended_namespace() : string {
+		$calling_class           = get_class( $this );
+		$reflection              = new \ReflectionClass( $calling_class );
+		$calling_class_namespace = $reflection->getNamespaceName();
+
+		if ( $this instanceof AbstractSubCommand ) {
+			$calling_class_namespace .= '\\Arg';
+		} elseif ( $this instanceof AbstractCommand ) {
+			$calling_class_namespace .= '\\SubCommand';
+		} else {
+			throw new \Exception( 'The class should autoload something.' );
+		}
+
+		return $calling_class_namespace;
+	}
+
 }

--- a/src/Interfaces/ExtensibleInterface.php
+++ b/src/Interfaces/ExtensibleInterface.php
@@ -13,5 +13,5 @@ namespace DonMhico\OopsCommand\Interfaces;
  * @since 0.0.1
  */
 interface ExtensibleInterface {
-	public function get_extended_namespace();
+	public function get_extended_namespace() : string;
 }

--- a/src/OopsCommand.php
+++ b/src/OopsCommand.php
@@ -16,17 +16,6 @@ use DonMhico\OopsCommand\Abstracts\AbstractCommand;
  */
 class OopsCommand extends AbstractCommand {
 	/**
-	 * Returns the namespace of the sub commands to be loaded.
-	 *
-	 * @since 0.0.1
-	 *
-	 * @return string
-	 */
-	public function get_extended_namespace() {
-		return __NAMESPACE__ . '\\SubCommand';
-	}
-
-	/**
 	 * Perform the command
 	 *
 	 * @since 0.0.1

--- a/src/SubCommand/Generate/Generate.php
+++ b/src/SubCommand/Generate/Generate.php
@@ -14,17 +14,6 @@ use DonMhico\OopsCommand\Abstracts\AbstractSubCommand;
  */
 class Generate extends AbstractSubCommand {
 	/**
-	 * Namespace for the \Args.
-	 *
-	 * @since 0.0.1
-	 *
-	 * @return string
-	 */
-	public function get_extended_namespace() {
-		return __NAMESPACE__ . '\\Arg';
-	}
-
-	/**
 	 * Perform the sub command
 	 *
 	 * @since 0.0.1

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,37 @@
+<?php
+// phpcs:enable
+require_once VENDOR_DIR . '/autoload.php';
+require_once WP_CLI_ROOT . '/php/utils.php';
+
+if ( ! function_exists( 'wpcli_tests_include_config' ) ) {
+	var_dump( 'mico' );
+	function wpcli_tests_include_config( array $config_filenames = [] ) {
+		$config_filename = false;
+		foreach ( $config_filenames as $filename ) {
+			if ( file_exists( PACKAGE_ROOT . '/' . $filename ) ) {
+				$config_filename = PACKAGE_ROOT . '/' . $filename;
+				break;
+			}
+		}
+
+		if ( $config_filename ) {
+			$config  = file_get_contents( $config_filename );
+			$matches = null;
+			$pattern = '/bootstrap="(?P<bootstrap>.*)"/';
+			$result  = preg_match( $pattern, $config, $matches );
+			if ( isset( $matches['bootstrap'] ) && file_exists( $matches['bootstrap'] ) ) {
+				var_dump( 'mico' );
+				include_once PACKAGE_ROOT . '/' . $matches['bootstrap'];
+			}
+		}
+	}
+}
+
+wpcli_tests_include_config(
+	[
+		'phpunit.xml',
+		'.phpunit.xml',
+		'phpunit.xml.dist',
+		'.phpunit.xml.dist',
+	]
+);

--- a/tests/test-AbstractCommand.php
+++ b/tests/test-AbstractCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+class AbstractCommandTest extends \PHPUnit\Framework\TestCase {
+	public function testGetExtendedNamespace() {
+		// phpcs:ignore WordPress.Classes.ClassInstantiation.MissingParenthesis
+		$sample_abstract_command_obj = new class extends \DonMhico\OopsCommand\Abstracts\AbstractCommand {
+			public function call() {
+			}
+		};
+
+		$this->assertStringEndsWith(
+			'\\SubCommand',
+			$sample_abstract_command_obj->get_extended_namespace()
+		);
+
+		// phpcs:ignore WordPress.Classes.ClassInstantiation.MissingParenthesis
+		$sample_abstract_subcommand_obj = new class extends \DonMhico\OopsCommand\Abstracts\AbstractSubCommand {
+			public function call() {
+			}
+		};
+
+		$this->assertStringEndsWith(
+			'\\Arg',
+			$sample_abstract_subcommand_obj->get_extended_namespace()
+		);
+	}
+}


### PR DESCRIPTION
This PR has 2 updates.

1. Pre this PR, the OopsCommand and each extending AbstractSubCommand class should implement get_extended_namespace(). I refactored and place it in AbstractCommand class so it will automatically get the proper values.

2. Setup unit tests.